### PR TITLE
PD-301 Unable to start service ... invalid null provider

### DIFF
--- a/android/common/src/main/java/com/marianhello/bgloc/provider/RawLocationProvider.java
+++ b/android/common/src/main/java/com/marianhello/bgloc/provider/RawLocationProvider.java
@@ -46,7 +46,12 @@ public class RawLocationProvider extends AbstractLocationProvider implements Loc
         criteria.setPowerRequirement(Criteria.POWER_HIGH);
 
         try {
-            locationManager.requestLocationUpdates(locationManager.getBestProvider(criteria, true), mConfig.getInterval(), mConfig.getDistanceFilter(), this);
+            String provider = locationManager.getBestProvider(criteria, true);
+            if (provider == null) {
+                logger.warn("No location providers available");
+                return;
+            }
+            locationManager.requestLocationUpdates(provider, mConfig.getInterval(), mConfig.getDistanceFilter(), this);
             isStarted = true;
         } catch (SecurityException e) {
             logger.error("Security exception: {}", e.getMessage());


### PR DESCRIPTION
[문제]
Android: Unable to start service ... invalid null provider
[PD-301]

[해결]
provider가 null 이면 위치 조회시도하지 않음

[PD-301]: https://olulo.atlassian.net/browse/PD-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ